### PR TITLE
Remove lancet from run dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - jupyter
     - notebook
     - ipython
-    - lancet
 
 test:
   imports:


### PR DESCRIPTION
As the title says, lancet isn't and shouldn't be required.