### PR TITLE
Configure dev releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,4 @@ install:
 script:
   - conda build ./recipe
 
-  - upload_or_check_non_existence ./recipe conda-forge --channel=main
+  - upload_or_check_non_existence ./recipe conda-forge --channel=dev

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,4 +71,4 @@ build: off
 test_script:
     - conda.exe build recipe --quiet
 deploy_script:
-    - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main
+    - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=dev

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -59,7 +59,7 @@ conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
 conda build /recipe_root --quiet || exit 1
-upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+upload_or_check_non_existence /recipe_root conda-forge --channel=dev || exit 1
 
 touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,7 @@ travis:
 appveyor:
   secure:
     BINSTAR_TOKEN: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
+
+channels:
+  targets:
+    - [conda-forge, dev]


### PR DESCRIPTION
Configures the newly created `dev` branch to publish to a `dev` label as opposed to `main` under the `conda-forge` channel.

cc @jlstevens 

also cc-ing @CJ-Wright @isuruf (for awareness)