### PR TITLE
Updated recipe to work with versions specified by git tags

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,7 @@ package:
 source:
   git_url: https://github.com/ioam/holoviews.git
   git_rev: v{{version}}
+  git_depth: 1
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   git_url: https://github.com/ioam/holoviews.git
   git_rev: v{{version}}
-  git_depth: 1
+  git_depth: 60
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,12 @@
-{% set version = "1.9.5" %}
+{% set version = "1.10.0a2" %}
 
 package:
   name: holoviews
   version: {{ version }}
 
 source:
-  fn: holoviews-{{ version }}.tar.gz
-  url: https://github.com/ioam/holoviews/archive/v{{version}}.tar.gz
-  sha256: 89bdf9708ab58b43d4c690846867be5559a9cb4b7c215611db646ed3d54c4169
+  git_url: https://github.com/ioam/holoviews.git
+  git_rev: v{{version}}
 
 build:
   number: 0


### PR DESCRIPTION

Testing locally, I find that this change to the source in the recipe allows the version to be set correctly with the versioning system used by holoviews (based on git tags). If all goes well, this PR should supersede #27. 

That said, before it is merged, it is worth making sure that such a development release will be only accessible under ``label/dev``.