### PR TITLE
Sync recipe with AnacondaRecipes

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,8 +38,15 @@ test:
 about:
   home: www.holoviews.org
   summary: Stop plotting your data - annotate your data and let it visualize itself.
+  description: |
+    HoloViews is an open-source Python library designed to make data analysis
+    and visualization seamless and simple. With HoloViews, you can usually
+    express what you want to do in very few lines of code, letting you focus on
+    what you are trying to explore and convey, not on the process of plotting.
   license: BSD 3-Clause
   license_file: LICENSE.txt
+  dev_url: https://github.com/ioam/holoviews
+  doc_url: http://holoviews.org/getting_started/index.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 
 requirements:
-  build:
+  host:
     - python
     - pip
     - param >=1.6.1,<2.0


### PR DESCRIPTION
Adds additional information to the about section and updates the recipe to use the new host requirements section recommended when using conda build 3.

These changes are in the AnacondaRecipes recipe, including these in conda-forge will make it easier to keep the two recipes in sync.