### PR TITLE
Updated recipe for version 1.12.1 (build 2)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - bokeh >=1.1.0
     - jupyter
     - notebook
+    - ipython >=5.4.0
     - pyviz_comms >=0.7.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
   entry_points:
     - holoviews = holoviews.util.command:main
@@ -28,7 +28,6 @@ requirements:
     - bokeh >=1.1.0
     - jupyter
     - notebook
-    - ipython >=5.4.0,<=7.1.1  # <=7.1.1 due to tab completion regression
     - pyviz_comms >=0.7.0
 
 test:


### PR DESCRIPTION
Sorry about this! There is one more (un)pinning change we want for this release as we no longer want to constrain the IPython version to <=7.1.1 (which was causing some problems for our users).