### PR TITLE
Don't depend on jupyter

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
   entry_points:
     - holoviews = holoviews.util.command:main
@@ -26,7 +26,6 @@ requirements:
     - numpy >=1.0
     - matplotlib >=2.1
     - bokeh >=1.1.0
-    - jupyter
     - notebook
     - ipython >=5.4.0
     - pyviz_comms >=0.7.2


### PR DESCRIPTION
`jupyter` is a conda metapackage for enduser to conviently install all `jupyter` components and should not be used as `run` dependency in a package. The dependencies on `notebook` and `ipython` should be enough for this to run.

Background on why this is important: `jupyter` includes a dependency on `qtconsole` which in turn pulls in `qt` that adds a lot of size to a conda installation.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
