### PR TITLE
Depend on matplotlib-base

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
   entry_points:
     - holoviews = holoviews.util.command:main
@@ -24,7 +24,7 @@ requirements:
     - python
     - param >=1.9.0,<2.0
     - numpy >=1.0
-    - matplotlib >=2.1
+    - matplotlib-base >=2.1
     - bokeh >=1.1.0
     - notebook
     - ipython >=5.4.0


### PR DESCRIPTION
`matplotlib` is nowadays a simple convenience package for endusers to install all `matplotlib` dependencies inkl the optional ones. Packages should instead depend on `matplotlib-base` that excludes the heavy dependency on qt. See also https://github.com/conda-forge/matplotlib-feedstock/blob/master/recipe/meta.yaml#L69-L79

This should now finally get rid of the Qt dependency in here.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
