### PR TITLE
fix: holoviews 1.12.7 import broken on python 3.10+

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.22.1" %}
-{% set python_min = "3.10" %}
+{% set python_min = "3.9" %}
 
 package:
   name: holoviews


### PR DESCRIPTION
Fixes #120